### PR TITLE
caa: Fix missing defaults and yq in image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.5-labs
 ARG BUILD_TYPE=dev
 ARG BUILDER_BASE=quay.io/confidential-containers/golang-fedora:1.20.8-36
 ARG BASE=registry.fedoraproject.org/fedora:38
@@ -12,10 +13,16 @@ ARG RELEASE_BUILD
 ARG COMMIT
 ARG VERSION
 ARG TARGETARCH
+ARG YQ_VERSION
+ARG YQ_CHECKSUM
+
+ADD --checksum=${YQ_CHECKSUM} https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64 /usr/local/bin/yq
+RUN chmod a+x /usr/local/bin/yq
+
 WORKDIR /work
 COPY go.mod go.sum ./
 RUN go mod download
-COPY entrypoint.sh Makefile ./
+COPY entrypoint.sh Makefile Makefile.defaults versions.yaml ./
 COPY cmd   ./cmd
 COPY pkg   ./pkg
 COPY proto ./proto

--- a/Makefile
+++ b/Makefile
@@ -154,11 +154,11 @@ clean: ## Remove binaries.
 
 .PHONY: image
 image: .git-commit ## Build and push docker image to $registry
-	COMMIT=$(COMMIT) VERSION=$(VERSION) hack/build.sh -i
+	COMMIT=$(COMMIT) VERSION=$(VERSION) YQ_VERSION=$(YQ_VERSION) YQ_CHECKSUM=$(YQ_CHECKSUM) hack/build.sh -i
 
 .PHONY: image-with-arch
 image-with-arch: .git-commit ## Build the per arch image
-	COMMIT=$(COMMIT) VERSION=$(VERSION) hack/build.sh -a
+	COMMIT=$(COMMIT) VERSION=$(VERSION) YQ_VERSION=$(YQ_VERSION) YQ_CHECKSUM=$(YQ_CHECKSUM) hack/build.sh -a
 
 ##@ Deployment
 

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -57,6 +57,8 @@ function build_caa_payload_image() {
 		--build-arg BUILD_TYPE="${build_type}" \
 		--build-arg VERSION="${version}" \
 		--build-arg COMMIT="${commit}" \
+		--build-arg YQ_VERSION="${YQ_VERSION}" \
+		--build-arg YQ_CHECKSUM="${YQ_CHECKSUM}" \
 		-f Dockerfile \
 		${tag_string} \
 		--push \
@@ -76,7 +78,7 @@ function get_arch_specific_tag_string() {
 	echo "$tag_string"
 }
 
-# accept one arch as --platform 
+# accept one arch as --platform
 function build_caa_payload_arch_specific() {
 	pushd "${script_dir}/.."
 
@@ -100,6 +102,8 @@ function build_caa_payload_arch_specific() {
 		--build-arg BUILD_TYPE="${build_type}" \
 		--build-arg VERSION="${version}" \
 		--build-arg COMMIT="${commit}" \
+		--build-arg YQ_VERSION="${YQ_VERSION}" \
+		--build-arg YQ_CHECKSUM="${YQ_CHECKSUM}" \
 		-f Dockerfile \
 		${tag_string} \
 		--push \


### PR DESCRIPTION
After the changes in #1448 the root Makefile now references Makefile.defaults, this file and the yq binary need to be included for the build